### PR TITLE
update IDE internal error reporter to open a github issue instead of sending the report to jetbrains

### DIFF
--- a/idea/customization/base/resources/intellij.idea.customization.base.xml
+++ b/idea/customization/base/resources/intellij.idea.customization.base.xml
@@ -2,7 +2,7 @@
 <idea-plugin>
   <extensions defaultExtensionNs="com.intellij">
     <applicationService serviceInterface="com.intellij.platform.ide.customization.ExternalProductResourceUrls"
-                        serviceImplementation="com.intellij.idea.customization.base.IntelliJIdeaExternalResourceUrls"
+                        serviceImplementation="com.intellij.idea.customization.base.RebasedExternalResourceUrls"
                         overrides="true"/>
   </extensions>
 </idea-plugin>

--- a/idea/customization/base/src/RebasedExternalResourceUrls.kt
+++ b/idea/customization/base/src/RebasedExternalResourceUrls.kt
@@ -1,0 +1,46 @@
+package com.intellij.idea.customization.base
+
+import com.intellij.platform.ide.impl.customization.BaseJetBrainsExternalProductResourceUrls
+import com.intellij.util.Url
+import com.intellij.util.Urls
+
+internal class RebasedExternalResourceUrls : BaseJetBrainsExternalProductResourceUrls() {
+  override val basePatchDownloadUrl: Url
+    get() {
+      throw NotImplementedError()
+    }
+
+  override val productPageUrl: Url
+    get() = Urls.newFromEncoded("https://github.com/detachhead/rebased")
+
+  override val bugReportUrl
+    get() = { description: String ->
+      productPageUrl.resolve("issues/new").addParameters(mapOf("body" to description, "labels" to "IDE internal error"))
+    }
+
+  override val youtrackProjectId: String
+    get() {
+      throw NotImplementedError()
+    }
+
+  override val shortProductNameUsedInForms
+    get() = null
+
+  override val useInIdeGeneralFeedback: Boolean
+    get() = false
+
+  override val useInIdeEvaluationFeedback: Boolean
+    get() = false
+
+  override val youTubeChannelUrl
+    get() = null
+
+  override val keyboardShortcutsPdfUrl
+    get() = null
+
+  override val gettingStartedPageUrl
+    get() = null
+
+  override val baseWebHelpUrl
+    get() = null
+}

--- a/platform/platform-impl/resources/messages/DiagnosticBundle.properties
+++ b/platform/platform-impl/resources/messages/DiagnosticBundle.properties
@@ -32,6 +32,7 @@ error.dialog.notice.label.expanded=By submitting this report, you agree to the t
 error.dialog.submit.anonymous=Submit anonymously or <a href="#">Log In</a>
 error.dialog.submit.named=Submit as <b>{0}</b> or <a href="#">change account</a>
 error.report.to.jetbrains.action=&Report to JetBrains
+error.report.to.github.action=&Open Issue on GitHub
 error.report.all.action=Report All
 error.report.and.clear.all.action=Report and Clear All
 error.report.impossible.action=Report Exception
@@ -40,6 +41,7 @@ error.dialog.clear.all.action=&Clear all
 error.dialog.notice.anonymous=I agree to my hardware configuration, software configuration, product information, and the error details shown above \
   being used by JetBrains s.r.o. ("JetBrains") to let JetBrains improve its products and to provide me with support service \
   in accordance with the end-user agreement of <a href="https://www.jetbrains.com/legal/agreements/exception_analyzer.html">JetBrains Exception Analyzer</a>.
+error.dialog.notice.github=Your browser will be opened to a new issue form with the information provided here pre-filled. It will not be submitted automatically.
 error.dialog.notice.third-party.plugin.exception=I agree that my hardware configuration, software configuration, product information, and the error details shown above\
   \ might be used by Jetbrains s.r.o. (\u201CJetBrains\u201D) and the author of the plugin to improve their products and provide me with support service by JetBrains\
   \ in accordance with the relevant <a href="https://www.jetbrains.com/legal/agreements/exception_analyzer.html">Agreement</a>.\

--- a/platform/platform-impl/src/com/intellij/diagnostic/GithubIssueReporter.kt
+++ b/platform/platform-impl/src/com/intellij/diagnostic/GithubIssueReporter.kt
@@ -1,0 +1,50 @@
+package com.intellij.diagnostic
+
+import com.intellij.openapi.diagnostic.ErrorReportSubmitter
+import com.intellij.openapi.diagnostic.IdeaLoggingEvent
+import org.jetbrains.annotations.ApiStatus
+
+import com.intellij.ide.BrowserUtil
+
+import com.intellij.openapi.diagnostic.SubmittedReportInfo
+import com.intellij.platform.ide.customization.ExternalProductResourceUrls
+import com.intellij.util.Consumer
+import java.awt.Component
+
+/**
+ * used to prevent errors from URLs being too big. this isn't the exact limit just a ballpark
+ */
+private const val maxDescriptionLength = 6000
+
+open class GithubIssueReporter internal constructor() : ErrorReportSubmitter() {
+  override fun getReportActionText(): String = DiagnosticBundle.message("error.report.to.github.action")
+
+  override fun getPrivacyNoticeText(): String = DiagnosticBundle.message("error.dialog.notice.github")
+
+  @ApiStatus.OverrideOnly
+  override fun submit(
+    events: Array<IdeaLoggingEvent>,
+    additionalInfo: String?,
+    parentComponent: Component,
+    consumer: Consumer<in SubmittedReportInfo>,
+  ): Boolean {
+    // determine how much of each stack trace to show based on how many there are
+    val maxStackTraceLength = (maxDescriptionLength - (additionalInfo?.length ?: 0) / events.size)
+    // this looks gross as hell, but apparently trimIndent doesn't work with interpolation, and github is very particular about the newlines
+    // necessary for details blocks to work...
+    val errorDescriptions = events.joinToString("\n") {
+"""```
+${it.throwableText.take((maxStackTraceLength))}
+```"""
+    }
+    val description =
+"""$additionalInfo
+<details><summary>Exceptions</summary><p>
+
+$errorDescriptions
+</p></details>"""
+    BrowserUtil.open(ExternalProductResourceUrls.getInstance().bugReportUrl!!(description).toString())
+    consumer.consume(SubmittedReportInfo(SubmittedReportInfo.SubmissionStatus.NEW_ISSUE))
+    return true
+  }
+}

--- a/platform/platform-impl/src/com/intellij/openapi/updateSettings/impl/UpdateInfo.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/updateSettings/impl/UpdateInfo.kt
@@ -17,6 +17,8 @@ import com.intellij.openapi.util.JDOMUtil
 import com.intellij.openapi.util.NlsSafe
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.util.SystemInfoRt
+import com.intellij.platform.ide.customization.ExternalProductResourceUrls
+import com.intellij.platform.ide.impl.customization.BaseJetBrainsExternalProductResourceUrls
 import org.jdom.Element
 import org.jdom.JDOMException
 import org.jetbrains.annotations.ApiStatus.Internal
@@ -65,7 +67,7 @@ fun parseUpdateData(
   check(newVersion != null && releaseDescription != null) {
     "failed to check for updates: newVersion=${newVersion}, releaseDescription=${releaseDescription}"
   }
-  val githubUrl = "https://github.com/detachhead/rebased"
+  val githubUrl = (ExternalProductResourceUrls.getInstance() as BaseJetBrainsExternalProductResourceUrls).productPageUrl
   val releasesUrl = "$githubUrl/releases/latest"
   // we convert the release info to the format from https://www.jetbrains.com/updates/updates.xml because it's easier to just do that
   // than to update all the classes that can only be constructed from the parsed xml

--- a/platform/platform-resources/src/META-INF/PlatformExtensions.xml
+++ b/platform/platform-resources/src/META-INF/PlatformExtensions.xml
@@ -20,7 +20,7 @@
       serviceImplementation="com.intellij.openapi.editor.impl.EditorThreadingImpl"
     />
 
-    <errorHandler implementation="com.intellij.diagnostic.ITNReporter"/>
+    <errorHandler implementation="com.intellij.diagnostic.GithubIssueReporter"/>
     <appStarter id="save" implementation="com.intellij.openapi.application.SaveStarter"/>
     <appStarter id="exit" implementation="com.intellij.openapi.application.ExitStarter"/>
     <appStarter id="dumpLaunchParameters" implementation="com.intellij.openapi.application.DumpLaunchParametersStarter"/>


### PR DESCRIPTION
fixes #44 