### PR TITLE
use lightweight JBR without JCEF to reduce bundle size

### DIFF
--- a/build/src/org/jetbrains/intellij/build/RebasedProperties.kt
+++ b/build/src/org/jetbrains/intellij/build/RebasedProperties.kt
@@ -57,6 +57,7 @@ open class RebasedProperties(private val communityHomeDir: Path) : JetBrainsProd
     useSplash = false
     buildCrossPlatformDistribution = true
     buildSourcesArchive = true
+    runtimeDistribution = JetBrainsRuntimeDistribution.LIGHTWEIGHT
 
     productLayout.productImplementationModules = listOf(
       "intellij.platform.starter",


### PR DESCRIPTION
As I understand it, JCEF is not needed here.


According to Claude:
## What uses JCEF in IntelliJ?

| Feature | What it does with JCEF | Fallback when JCEF absent |
|---------|----------------------|---------------------------|
| **Markdown preview** | Renders markdown as HTML in a browser panel | Falls back to alternative provider (Compose renderer exists) |
| **HTML file editor** | Opens HTML files in embedded browser | Falls back to plain text editor |
| **What's New dialog** | Shows release notes in embedded browser | Opens external browser instead |
| **SVG viewer** | Renders SVGs via Chromium | Falls back to Swing image viewer |
| **Web preview** | Live preview of web files | Feature not available |
| **About dialog** | Shows JCEF version info | Skips that section |

Disabling it freed 300 MB:
% du -sm /Applications/Rebased.app
1380	/Applications/Rebased.app
% du -sm /Applications/Rebased\ 2.app
1077	/Applications/Rebased 2.app

There is also intellij.libraries.jcef.jar leftover, 14 MB. It should probably be deleted too.

You can check built binaries in the fork.