### PR TITLE
enable "Clear initial commit message" by default

### DIFF
--- a/platform/vcs-api/shared/src/com/intellij/openapi/vcs/VcsConfiguration.java
+++ b/platform/vcs-api/shared/src/com/intellij/openapi/vcs/VcsConfiguration.java
@@ -128,7 +128,7 @@ public final class VcsConfiguration implements PersistentStateComponent<VcsConfi
     }
   }
 
-  public boolean CLEAR_INITIAL_COMMIT_MESSAGE = false;
+  public boolean CLEAR_INITIAL_COMMIT_MESSAGE = true;
 
   @Property(surroundWithTag = false)
   @XCollection(elementName = "MESSAGE")


### PR DESCRIPTION
fixes #117

i have no idea why this is even an option let alone the default behavior