### PR TITLE
remove ctrl+G keyboard shortcut to open a new git log tab because it conflicts with go to line number

### DIFF
--- a/platform/vcs-log/impl/resources/intellij.platform.vcs.log.impl.xml
+++ b/platform/vcs-log/impl/resources/intellij.platform.vcs.log.impl.xml
@@ -166,7 +166,6 @@
       <!--<action class="com.intellij.vcs.log.ui.actions.OpenAnotherLogTabAction$InToolWindow" id="Vcs.Log.OpenAnotherTab"-->
       <!--        icon="AllIcons.General.Add"/>-->
       <action class="com.intellij.vcs.log.ui.actions.OpenAnotherLogTabAction$InEditor" id="Vcs.Log.OpenAnotherTabInEditor" icon="AllIcons.Actions.OpenNewTab">
-        <keyboard-shortcut first-keystroke="control G" keymap="$default"/>
         <add-to-group group-id="EditorTabsEntryPoint" anchor="before" relative-to-action="RecentFiles"/>
       </action>
       <action class="com.intellij.vcs.log.ui.actions.RefreshLogAction" id="Vcs.Log.Refresh" use-shortcut-of="Refresh" icon="AllIcons.Actions.Refresh"/>


### PR DESCRIPTION
this was left over from the other git client fork as an easy way to re-open the log if you accidentally close it, but now that the main log tab isn't closable it's no longer needed. users can always re-add the keyboard shortcut in their keymap settings if they want.