### PR TITLE
fix rebased being registered as the default editor for java & kotlin files on macOS

### DIFF
--- a/platform/build-scripts/src/org/jetbrains/intellij/build/MacDistributionCustomizer.kt
+++ b/platform/build-scripts/src/org/jetbrains/intellij/build/MacDistributionCustomizer.kt
@@ -304,7 +304,7 @@ inline fun communityMacCustomizer(projectHome: Path, configure: MacCustomizerBui
     icnsPathForEAP = "build/conf/ideaCE/mac/images/rebased.icns"
     urlSchemes = listOf("rebased")
     associateIpr = true
-    fileAssociations = FileAssociation.from("java", "groovy", "kt", "kts")
+    fileAssociations = emptyList()
     bundleIdentifier = "io.github.detachhead.rebased"
     dmgImagePath = "build/conf/ideaCE/mac/images/dmg_background.tiff"
     

--- a/platform/build-scripts/src/org/jetbrains/intellij/build/WindowsDistributionCustomizer.kt
+++ b/platform/build-scripts/src/org/jetbrains/intellij/build/WindowsDistributionCustomizer.kt
@@ -248,7 +248,7 @@ inline fun communityWindowsCustomizer(projectHome: Path, configure: WindowsCusto
     icoPath = "build/conf/ideaCE/win/images/rebased.ico"
     icoPathForEAP = "build/conf/ideaCE/win/images/rebased.ico"
     installerImagesPath = "build/conf/ideaCE/win/images"
-    fileAssociations = listOf()
+    fileAssociations = emptyList()
     
     fullName { "Rebased" }
     


### PR DESCRIPTION
fixes #190 