### PR TITLE
Fix crash when `.idea` folder is stored outside the project root

### DIFF
--- a/platform/external-system-impl/resources/META-INF/ExternalSystemExtensions.xml
+++ b/platform/external-system-impl/resources/META-INF/ExternalSystemExtensions.xml
@@ -118,7 +118,7 @@
     <!--Execution-->
     <programRunner implementation="com.intellij.openapi.externalSystem.service.execution.ExternalSystemTaskRunner"/>
 
-    <streamProviderFactory implementation="com.intellij.openapi.externalSystem.configurationStore.ExternalSystemStreamProviderFactory"/>
+    <!--<streamProviderFactory implementation="com.intellij.openapi.externalSystem.configurationStore.ExternalSystemStreamProviderFactory"/>-->
 
     <moduleService serviceInterface="com.intellij.openapi.externalSystem.ExternalSystemModulePropertyManager"
                    serviceImplementation="com.intellij.openapi.externalSystem.service.project.ExternalSystemModulePropertyManagerBridge"/>


### PR DESCRIPTION
not sure what this is, but for some reason it was causing a crash when opening a project, but not when running from the debug config...