### PR TITLE
Improve ci security

### DIFF
--- a/.github/actions/upload_ide/action.yml
+++ b/.github/actions/upload_ide/action.yml
@@ -42,6 +42,6 @@ runs:
         retention-days: 1
         path: |
           ${{inputs.artifacts_dir}}/*.${{inputs.extension}}
-          ${{inputs.artifacts_dir}}/*.spdx.json
+          ${{inputs.artifacts_dir}}/*.${{inputs.extension}}.spdx.json
           ${{inputs.artifacts_dir}}/*.sha256
           ${{inputs.artifacts_dir}}/*.zsync

--- a/.github/workflows/IntelliJ_IDEA.yml
+++ b/.github/workflows/IntelliJ_IDEA.yml
@@ -64,7 +64,7 @@ jobs:
           title: ${{ needs.get_version.outputs.version }}
           automatic_release_tag: ${{ needs.get_version.outputs.version }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          prerelease: false # ideally this would be true because rebased has not had a stable release yet, but i don't like that prereleases don't appear on the sidebar
+          prerelease: false
           draft: true
           files: |
             **/*.tar.gz

--- a/.github/workflows/IntelliJ_IDEA.yml
+++ b/.github/workflows/IntelliJ_IDEA.yml
@@ -72,4 +72,5 @@ jobs:
             **/*.zsync
             **/*.exe
             **/*.dmg
+            **/*.spdx.json
             

--- a/.github/workflows/ide_build_and_upload.yml
+++ b/.github/workflows/ide_build_and_upload.yml
@@ -136,11 +136,17 @@ jobs:
           ln -s usr/bin/idea.png appdir/rebased.png
 
       - name: Install appimagetool
+        # this sucks. bash is the worst language ever made. appimagetool should be available on a package manager with lockfile support
+        env:
+          filename: "appimagetool-x86_64.AppImage"
+          sha256: "ed4ce84f0d9caff66f50bcca6ff6f35aae54ce8135408b3fa33abfc3cb384eb0"
         # language=bash
         run: |
-          wget -q https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
-          mv appimagetool-x86_64.AppImage ./appimagetool
-          chmod +x appimagetool
+          set -euo pipefail # work properly flags! we don't want to risk running it even if the validation fails
+          wget -q https://github.com/AppImage/appimagetool/releases/download/1.9.1/$filename
+          echo "$sha256 $filename" | sha256sum -c
+          chmod +x $filename
+          mv $filename ./appimagetool
 
       - name: Build AppImage
         env:


### PR DESCRIPTION
addressing some of the security concerns from https://github.com/git/git-scm.com/pull/2132#issuecomment-4517499049

- [x] pin & verify hash of appimagetool
- [x] pin actions
- [x] enable immutable releases
- [x] include spdx files in the releases