### PR TITLE
Update Homebrew action to use LanikSJ version

### DIFF
--- a/.github/workflows/publish_to_package_managers.yml
+++ b/.github/workflows/publish_to_package_managers.yml
@@ -15,7 +15,7 @@ jobs:
   homebrew:
     runs-on: macos-latest
     steps:
-    - uses: FriesI23/action-homebrew-bump-cask@561bbe447f8915a50a62e65483061bea1e7f136f
+    - uses: LanikSJ/homebrew-bump-cask@d5866213d3bef867ee98352732bc26ea165c66c1 #v1
       with:
         # Required, custom GitHub access token with the 'public_repo' and 'workflow' scopes
         token: ${{ secrets.HOMEBREW_TOKEN }}


### PR DESCRIPTION
This action should be updated and maintained more often than the actual brew bump cask action. Anyway, the problems we faced were related to brew, not to the action.

EDIT: I also found the issue thacaused the cask to fail mysteriously the sha256, its' related to the `runs-on` input that should be set to `macos-26` or `macos-latest`not to `ubuntu`. Check my [tap](https://github.com/fraluc06/homebrew-tap) If you want, we can also change the caks file to the other structure I prefer
