### PR TITLE
show a warning icon for local branches whose upstream was deleted

### DIFF
--- a/plugins/git4idea/backend/src/remoteApi/GitRepositoryToDtoConverter.kt
+++ b/plugins/git4idea/backend/src/remoteApi/GitRepositoryToDtoConverter.kt
@@ -12,6 +12,7 @@ import com.intellij.vcs.git.repo.GitOperationState
 import com.intellij.vcs.git.rpc.GitRepositoryDto
 import com.intellij.vcs.git.rpc.GitRepositoryStateDto
 import com.intellij.vcsUtil.VcsUtil
+import git4idea.GitStandardLocalBranch
 import git4idea.GitStandardRemoteBranch
 import git4idea.branch.GitBranchType
 import git4idea.branch.GitTagType
@@ -45,7 +46,8 @@ internal object GitRepositoryToDtoConverter {
       workingTrees = repository.workingTreeHolder.getWorkingTrees(),
       recentBranches = repository.branches.recentCheckoutBranches,
       operationState = convertOperationState(repository),
-      trackingInfo = convertTrackingInfo(repoInfo.branchTrackInfosMap)
+      trackingInfo = convertTrackingInfo(repoInfo.branchTrackInfosMap),
+      upstreamGoneBranches = repoInfo.upstreamGoneBranches.filterIsInstance<GitStandardLocalBranch>().toSet(),
     )
   }
 

--- a/plugins/git4idea/backend/src/repo/GitConfig.kt
+++ b/plugins/git4idea/backend/src/repo/GitConfig.kt
@@ -88,6 +88,20 @@ class GitConfig private constructor(
     }.toSet()
 
   /**
+   * Returns local branches that have a configured upstream (`branch.<name>.merge` + `branch.<name>.remote`)
+   * whose upstream remote branch is no longer present in [remoteBranches] — i.e. git's `gone` state
+   * (for example, after a `fetch --prune` removed the stale remote-tracking ref). Such branches have no
+   * resolved [GitBranchTrackInfo] (see [parseTrackInfos]), so this is the only way to detect them.
+   */
+  fun parseUpstreamGoneBranches(
+    localBranches: Collection<GitLocalBranch>,
+    remoteBranches: Collection<GitRemoteBranch>,
+  ): Set<GitLocalBranch> =
+    trackedInfos.mapNotNullTo(HashSet()) { config ->
+      if (isUpstreamConfiguredButGone(config, remoteBranches)) findLocalBranch(config.name, localBranches) else null
+    }
+
+  /**
    * Return core info
    */
   fun parseCore(): Core {
@@ -204,6 +218,19 @@ class GitConfig private constructor(
         return null
       }
       return GitBranchTrackInfo(localBranch, remoteBranch, merge)
+    }
+
+    private fun isUpstreamConfiguredButGone(branchConfig: BranchConfig, remoteBranches: Collection<GitRemoteBranch>): Boolean {
+      val remoteName = branchConfig.remote
+      val mergeName = branchConfig.merge
+      val rebaseName = branchConfig.rebase
+
+      if (mergeName.isNullOrBlank() && rebaseName.isNullOrBlank()) return false
+      if (remoteName.isNullOrBlank()) return false
+
+      val merge = mergeName != null
+      val remoteBranchName = StringUtil.unquoteString((if (merge) mergeName else rebaseName)!!)
+      return findRemoteBranch(remoteBranchName, remoteName, remoteBranches) == null
     }
 
     private fun findLocalBranch(branchName: String, localBranches: Collection<GitLocalBranch>): GitLocalBranch? {

--- a/plugins/git4idea/backend/src/repo/GitRepoInfo.kt
+++ b/plugins/git4idea/backend/src/repo/GitRepoInfo.kt
@@ -18,7 +18,9 @@ data class GitRepoInfo(val currentBranch: GitLocalBranch?,
                        val branchTrackInfos: Collection<GitBranchTrackInfo>,
                        val submodules: Collection<GitSubmoduleInfo>,
                        val hooksInfo: GitHooksInfo,
-                       val isShallow: Boolean) {
+                       val isShallow: Boolean,
+                       /** Local branches whose configured upstream no longer exists (git's `gone` state). */
+                       val upstreamGoneBranches: Set<GitLocalBranch> = emptySet()) {
   val branchTrackInfosMap: Map<String, GitBranchTrackInfo> =
     branchTrackInfos.associateByTo(CollectionFactory.createCustomHashingStrategyMap(GitReference.BRANCH_NAME_HASHING_STRATEGY)) { it.localBranch.name }
 

--- a/plugins/git4idea/backend/src/repo/GitRepositoryImpl.kt
+++ b/plugins/git4idea/backend/src/repo/GitRepositoryImpl.kt
@@ -209,6 +209,7 @@ class GitRepositoryImpl private constructor(
       val remoteBranches = state.remoteBranches
       val localBranches = state.localBranches
       val trackInfos = config.parseTrackInfos(state.localBranches.keys, state.remoteBranches.keys)
+      val upstreamGoneBranches = config.parseUpstreamGoneBranches(state.localBranches.keys, state.remoteBranches.keys)
 
       val hooksInfo = repositoryReader.readHooksInfo()
       val submoduleFile = root.toNioPath().resolve(".gitmodules")
@@ -223,7 +224,8 @@ class GitRepositoryImpl private constructor(
                   branchTrackInfos = trackInfos,
                   submodules = submodules,
                   hooksInfo = hooksInfo,
-                  isShallow = isShallow)
+                  isShallow = isShallow,
+                  upstreamGoneBranches = upstreamGoneBranches)
     }
   }
 

--- a/plugins/git4idea/backend/src/ui/branch/dashboard/BranchesTree.kt
+++ b/plugins/git4idea/backend/src/ui/branch/dashboard/BranchesTree.kt
@@ -21,6 +21,7 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.progress.util.BackgroundTaskUtil
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.util.NlsSafe
 import com.intellij.openapi.util.TextRange
 import com.intellij.openapi.util.registry.Registry
 import com.intellij.openapi.util.text.StringUtil
@@ -53,8 +54,10 @@ import com.intellij.vcs.git.branch.tree.GitBranchesTreeUtil
 import com.intellij.vcs.git.ui.GitBranchesTreeIconProvider
 import com.intellij.vcs.git.ui.GitIncomingOutgoingUi
 import com.intellij.vcsUtil.VcsImplUtil
+import com.intellij.xml.util.XmlStringUtil
 import git4idea.branch.GitBranchIncomingOutgoingManager
 import git4idea.config.GitVcsSettings
+import git4idea.i18n.GitBundle
 import git4idea.repo.GitRepository
 import git4idea.repo.GitRepositoryManager
 import git4idea.ui.branch.dashboard.BranchesDashboardActions.BranchesTreeActionGroup
@@ -119,7 +122,8 @@ internal class BranchesTreeComponent(project: Project) : DnDAwareTree() {
           descriptor.refInfo.ref,
           current = descriptor.refInfo.isCurrent,
           favorite = descriptor.refInfo.isFavorite,
-          selected = selected
+          selected = selected,
+          upstreamGone = descriptor.refInfo.isUpstreamGone
         )
         is BranchNodeDescriptor.Group, is BranchNodeDescriptor.RemoteGroup -> GitBranchesTreeIconProvider.forGroup()
           is BranchNodeDescriptor.Repository ->
@@ -139,7 +143,10 @@ internal class BranchesTreeComponent(project: Project) : DnDAwareTree() {
 
       if (refInfo is BranchInfo) {
         toolTipText =
-          if (refInfo.isLocalBranch) BranchPresentation.getTooltip(getBranchesTooltipData(refInfo.branchName, BranchesTreeSelection.getSelectedRepositories(value)))
+          if (refInfo.isLocalBranch) {
+            val trackingTooltip = BranchPresentation.getTooltip(getBranchesTooltipData(refInfo.branchName, BranchesTreeSelection.getSelectedRepositories(value)))
+            appendUpstreamGoneNote(trackingTooltip, refInfo.isUpstreamGone)
+          }
           else null
 
         val incomingOutgoingState = refInfo.incomingOutgoingState
@@ -167,6 +174,15 @@ internal class BranchesTreeComponent(project: Project) : DnDAwareTree() {
 
         LinkedBranchDataImpl(presentableRootName, branchName, trackedBranchName)
       }
+    }
+
+    private fun appendUpstreamGoneNote(trackingTooltip: @NlsSafe String?, isUpstreamGone: Boolean): @NlsSafe String? {
+      if (!isUpstreamGone) return trackingTooltip
+      val note = GitBundle.message("branch.upstream.gone.tooltip")
+      if (trackingTooltip.isNullOrBlank()) return note
+      // getTooltip() returns plain text for a single repo and `<tr>` rows for multiple repos
+      val body = if (trackingTooltip.contains("<tr")) "<table>$trackingTooltip</table>" else XmlStringUtil.escapeString(trackingTooltip)
+      return XmlStringUtil.wrapInHtml("$body<br>$note")
     }
 
     override fun paint(g: Graphics) {

--- a/plugins/git4idea/backend/src/ui/branch/dashboard/BranchesTreeModel.kt
+++ b/plugins/git4idea/backend/src/ui/branch/dashboard/BranchesTreeModel.kt
@@ -41,6 +41,10 @@ internal sealed interface RefInfo {
   val ref: GitReference
   val refName: String
     get() = ref.name
+
+  /** See [com.intellij.vcs.git.repo.isUpstreamGone]. Always `false` for refs that can't track an upstream (e.g. tags). */
+  val isUpstreamGone: Boolean
+    get() = false
 }
 
 internal data class BranchInfo(
@@ -53,6 +57,10 @@ internal data class BranchInfo(
   var isMy: ThreeState = ThreeState.UNSURE
   val branchName: @NlsSafe String get() = branch.name
   val isLocalBranch = branch is GitLocalBranch
+
+  override val isUpstreamGone: Boolean = (branch as? GitLocalBranch)?.let { local ->
+    repositories.isNotEmpty() && repositories.all { repo -> local in repo.info.upstreamGoneBranches }
+  } ?: false
 
   override val ref = branch
 

--- a/plugins/git4idea/shared/resources/messages/GitBundle.properties
+++ b/plugins/git4idea/shared/resources/messages/GitBundle.properties
@@ -1361,6 +1361,7 @@ delete.branch.operation.you.may.rollback.not.to.let.branches.diverge=You may rol
 
 branch.operation.could.not.0.operation.name.1.reference=Could not {0} {1}
 branch.operation.in={0} (in {1})
+branch.upstream.gone.tooltip=Upstream branch was deleted
 
 checkout.new.branch.operation.could.not.create.new.branch=Could not create new branch {0}
 checkout.new.branch.operation.error.during.rollback=Error during rollback

--- a/plugins/git4idea/shared/src/com/intellij/vcs/git/branch/tree/GitBranchesTreeRenderer.kt
+++ b/plugins/git4idea/shared/src/com/intellij/vcs/git/branch/tree/GitBranchesTreeRenderer.kt
@@ -24,9 +24,11 @@ import com.intellij.vcs.git.branch.popup.GitBranchesPopupStepBase
 import com.intellij.vcs.git.branch.tree.GitBranchesTreeModel.RefUnderRepository
 import com.intellij.vcs.git.branch.tree.GitBranchesTreeUtil.canHighlight
 import com.intellij.vcs.git.repo.GitRepositoryModel
+import com.intellij.vcs.git.repo.isUpstreamGone
 import com.intellij.vcs.git.ui.GitBranchesTreeIconProvider
 import git4idea.GitBranch
 import git4idea.GitReference
+import git4idea.GitStandardLocalBranch
 import org.jetbrains.annotations.ApiStatus
 import java.awt.Component
 import java.awt.Graphics2D
@@ -66,8 +68,11 @@ abstract class GitBranchesTreeRenderer(
                             selected: Boolean): Icon {
     val isCurrent = repositories.all { it.state.isCurrentRef(reference) }
     val isFavorite = repositories.all { it.favoriteRefs.contains(reference) }
+    val localBranch = reference as? GitStandardLocalBranch
+    val isUpstreamGone = localBranch != null &&
+                         repositories.isNotEmpty() && repositories.all { it.state.isUpstreamGone(localBranch) }
 
-    return GitBranchesTreeIconProvider.forRef(reference, current = isCurrent, favorite = isFavorite, favoriteToggleOnClick = favoriteToggleOnClickSupported, selected = selected)
+    return GitBranchesTreeIconProvider.forRef(reference, current = isCurrent, favorite = isFavorite, favoriteToggleOnClick = favoriteToggleOnClickSupported, selected = selected, upstreamGone = isUpstreamGone)
   }
 
   private fun getNodeIcon(treeNode: Any?, isSelected: Boolean): Icon? {

--- a/plugins/git4idea/shared/src/com/intellij/vcs/git/repo/GitRepositoriesHolder.kt
+++ b/plugins/git4idea/shared/src/com/intellij/vcs/git/repo/GitRepositoriesHolder.kt
@@ -183,6 +183,7 @@ class GitRepositoriesHolder(
         recentBranches = repositoryStateDto.recentBranches,
         operationState = repositoryStateDto.operationState,
         trackingInfo = repositoryStateDto.trackingInfo,
+        upstreamGoneBranches = repositoryStateDto.upstreamGoneBranches,
       )
 
     private fun getUpdateType(rpcEvent: GitRepositoryEvent): UpdateType? = when (rpcEvent) {
@@ -223,6 +224,7 @@ private class GitRepositoryStateImpl(
   override val recentBranches: List<GitStandardLocalBranch>,
   override val operationState: GitOperationState,
   private val trackingInfo: Map<String, GitStandardRemoteBranch>,
+  override val upstreamGoneBranches: Set<GitStandardLocalBranch>,
 ) : GitRepositoryState {
   override fun getTrackingInfo(branch: GitStandardLocalBranch): GitStandardRemoteBranch? = trackingInfo[branch.name]
 

--- a/plugins/git4idea/shared/src/com/intellij/vcs/git/repo/GitRepositoryState.kt
+++ b/plugins/git4idea/shared/src/com/intellij/vcs/git/repo/GitRepositoryState.kt
@@ -22,6 +22,10 @@ interface GitRepositoryState {
   val recentBranches: List<GitStandardLocalBranch>
   val operationState: GitOperationState
 
+  /** Local branches whose configured upstream no longer exists (git's `gone` state). See [isUpstreamGone]. */
+  val upstreamGoneBranches: Set<GitStandardLocalBranch>
+    get() = emptySet()
+
   val currentBranch: GitStandardLocalBranch? get() = (currentRef as? GitCurrentRef.LocalBranch)?.branch
 
   /**
@@ -37,3 +41,12 @@ interface GitRepositoryState {
 
   fun getTrackingInfo(branch: GitStandardLocalBranch): GitStandardRemoteBranch?
 }
+
+/**
+ * A local branch is considered orphaned ("upstream gone") when it has a configured upstream
+ * (tracking info), but that upstream branch is no longer present among the known remote branches.
+ * This matches git's `gone` status (e.g. `git branch -vv` showing `[origin/x: gone]`), which becomes
+ * true after a fetch with `--prune` removes the stale remote-tracking ref.
+ */
+@ApiStatus.Internal
+fun GitRepositoryState.isUpstreamGone(branch: GitStandardLocalBranch): Boolean = branch in upstreamGoneBranches

--- a/plugins/git4idea/shared/src/com/intellij/vcs/git/rpc/GitRepositoryApi.kt
+++ b/plugins/git4idea/shared/src/com/intellij/vcs/git/rpc/GitRepositoryApi.kt
@@ -146,4 +146,8 @@ class GitRepositoryStateDto(
    * Maps short names of local branches to their upstream branches.
    */
   val trackingInfo: Map<String, GitStandardRemoteBranch>,
+  /**
+   * Local branches whose configured upstream no longer exists (git's `gone` state).
+   */
+  val upstreamGoneBranches: Set<GitStandardLocalBranch>,
 )

--- a/plugins/git4idea/shared/src/com/intellij/vcs/git/ui/GitBranchesTreeIconProvider.kt
+++ b/plugins/git4idea/shared/src/com/intellij/vcs/git/ui/GitBranchesTreeIconProvider.kt
@@ -11,12 +11,13 @@ import javax.swing.Icon
 
 @ApiStatus.Internal
 object GitBranchesTreeIconProvider {
-  fun forRef(gitReference: GitReference, current: Boolean, favorite: Boolean, selected: Boolean, favoriteToggleOnClick: Boolean = false): Icon = when {
+  fun forRef(gitReference: GitReference, current: Boolean, favorite: Boolean, selected: Boolean, favoriteToggleOnClick: Boolean = false, upstreamGone: Boolean = false): Icon = when {
     selected && !favorite && favoriteToggleOnClick -> AllIcons.Nodes.NotFavoriteOnHover
     current && favorite -> DvcsImplIcons.CurrentBranchFavoriteLabel
     current -> DvcsImplIcons.CurrentBranchLabel
     favorite -> AllIcons.Nodes.Favorite
     gitReference is GitTag -> DvcsImplIcons.BranchLabel
+    upstreamGone -> AllIcons.General.Warning
     else -> AllIcons.Vcs.BranchNode
   }
 

--- a/plugins/git4idea/tests/git4idea/branch/GitOrphanedBranchIconTest.kt
+++ b/plugins/git4idea/tests/git4idea/branch/GitOrphanedBranchIconTest.kt
@@ -1,0 +1,69 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package git4idea.branch
+
+import com.intellij.icons.AllIcons
+import com.intellij.testFramework.LightPlatformTestCase
+import com.intellij.vcs.git.ref.GitCurrentRef
+import com.intellij.vcs.git.repo.GitHash
+import com.intellij.vcs.git.repo.GitOperationState
+import com.intellij.vcs.git.repo.GitRepositoryState
+import com.intellij.vcs.git.repo.isUpstreamGone
+import com.intellij.vcs.git.ui.GitBranchesTreeIconProvider
+import git4idea.GitStandardLocalBranch
+import git4idea.GitStandardRemoteBranch
+import git4idea.GitTag
+import git4idea.GitWorkingTree
+import icons.DvcsImplIcons
+
+class GitOrphanedBranchIconTest : LightPlatformTestCase() {
+
+  fun `test orphaned local branch uses the warning icon`() {
+    val branch = GitStandardLocalBranch("feature")
+    assertSame(AllIcons.General.Warning,
+               GitBranchesTreeIconProvider.forRef(branch, current = false, favorite = false, selected = false, upstreamGone = true))
+  }
+
+  fun `test current and favorite take priority over the warning`() {
+    val branch = GitStandardLocalBranch("feature")
+    assertSame(DvcsImplIcons.CurrentBranchLabel,
+               GitBranchesTreeIconProvider.forRef(branch, current = true, favorite = false, selected = false, upstreamGone = true))
+    assertSame(AllIcons.Nodes.Favorite,
+               GitBranchesTreeIconProvider.forRef(branch, current = false, favorite = true, selected = false, upstreamGone = true))
+  }
+
+  fun `test tag is never shown as orphaned`() {
+    val tag = GitTag("v1.0")
+    assertSame(DvcsImplIcons.BranchLabel,
+               GitBranchesTreeIconProvider.forRef(tag, current = false, favorite = false, selected = false, upstreamGone = true))
+  }
+
+  fun `test healthy local branch keeps the regular branch icon`() {
+    val branch = GitStandardLocalBranch("feature")
+    assertSame(AllIcons.Vcs.BranchNode,
+               GitBranchesTreeIconProvider.forRef(branch, current = false, favorite = false, selected = false, upstreamGone = false))
+  }
+
+  fun `test isUpstreamGone checks membership in the gone-upstream set`() {
+    val branch = GitStandardLocalBranch("feature")
+    val other = GitStandardLocalBranch("other")
+
+    assertTrue(state(upstreamGone = setOf(branch)).isUpstreamGone(branch))
+    assertFalse(state(upstreamGone = setOf(other)).isUpstreamGone(branch))
+    assertFalse(state(upstreamGone = emptySet()).isUpstreamGone(branch))
+  }
+
+  private fun state(upstreamGone: Set<GitStandardLocalBranch>): GitRepositoryState =
+    object : GitRepositoryState {
+      override val currentRef: GitCurrentRef? = null
+      override val revision: GitHash? = null
+      override val localBranches: Set<GitStandardLocalBranch> = emptySet()
+      override val remoteBranches: Set<GitStandardRemoteBranch> = emptySet()
+      override val tags: Set<GitTag> = emptySet()
+      override val workingTrees: Collection<GitWorkingTree> = emptyList()
+      override val recentBranches: List<GitStandardLocalBranch> = emptyList()
+      override val operationState: GitOperationState = GitOperationState.NORMAL
+      override val upstreamGoneBranches: Set<GitStandardLocalBranch> = upstreamGone
+      override fun getDisplayableBranchText(): String = ""
+      override fun getTrackingInfo(branch: GitStandardLocalBranch): GitStandardRemoteBranch? = null
+    }
+}

--- a/plugins/git4idea/tests/git4idea/branch/GitOrphanedBranchWidgetTest.kt
+++ b/plugins/git4idea/tests/git4idea/branch/GitOrphanedBranchWidgetTest.kt
@@ -1,0 +1,89 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package git4idea.branch
+
+import com.intellij.dvcs.repo.repositoryId
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.application.invokeAndWaitIfNeeded
+import com.intellij.openapi.vcs.Executor.cd
+import com.intellij.ui.tree.TreeTestUtil
+import com.intellij.ui.treeStructure.Tree
+import com.intellij.util.ui.tree.TreeUtil
+import com.intellij.vcs.git.branch.popup.GitBranchesPopupStepBase
+import com.intellij.vcs.git.branch.popup.GitDefaultBranchesPopupStep
+import com.intellij.vcs.git.branch.popup.GitDefaultBranchesTreeRenderer
+import com.intellij.vcs.git.branch.tree.GitBranchesTreeRenderer
+import com.intellij.vcs.git.repo.GitRepositoriesHolder
+import git4idea.repo.GitRepository
+import git4idea.test.GitPlatformTest
+import git4idea.test.branch
+import git4idea.test.git
+import kotlinx.coroutines.runBlocking
+import javax.swing.Icon
+
+/**
+ * End-to-end check that an orphaned local branch (configured upstream deleted on the remote, i.e. git's `gone` state)
+ * is rendered with the warning icon by the real branches-popup tree, exercising the whole pipeline:
+ * git config -> [git4idea.repo.GitConfig.parseUpstreamGoneBranches] -> repo info -> DTO -> shared state -> renderer.
+ */
+class GitOrphanedBranchWidgetTest : GitPlatformTest() {
+  private lateinit var repo: GitRepository
+  private lateinit var popupStep: GitBranchesPopupStepBase
+
+  override fun setUp() {
+    super.setUp()
+    repo = setupRepositories(projectPath, "parent", "bro-repo").projectRepo
+    cd(projectPath)
+    refresh()
+    repositoryManager.updateAllRepositories()
+    runBlocking { GitRepositoriesHolder.getInstance(project).awaitInitialization() }
+  }
+
+  fun testOrphanedBranchUsesWarningIcon() {
+    // A healthy branch that still tracks an existing remote branch.
+    repo.branch("healthy")
+    repo.git("push -u origin healthy")
+
+    // An orphaned branch: push & set upstream, then delete it on the remote and prune locally.
+    // The branch.<name>.merge/remote config survives, but refs/remotes/origin/gone-feature is removed.
+    repo.branch("gone-feature")
+    repo.git("push -u origin gone-feature")
+    repo.git("push origin --delete gone-feature")
+    repo.git("fetch --prune origin")
+
+    repo.update()
+    repositoryManager.updateAllRepositories()
+    runBlocking { GitRepositoriesHolder.getInstance(project).awaitInitialization() }
+
+    val icons = iconsByText(buildTestTree())
+
+    assertEquals("Orphaned branch must use the warning icon", AllIcons.General.Warning, icons["gone-feature"])
+    assertEquals("Healthy tracking branch must keep the regular branch icon", AllIcons.Vcs.BranchNode, icons["healthy"])
+  }
+
+  private fun iconsByText(tree: Tree): Map<String, Icon?> = invokeAndWaitIfNeeded {
+    val renderer = tree.cellRenderer as GitBranchesTreeRenderer
+    val result = LinkedHashMap<String, Icon?>()
+    for (row in 0 until tree.rowCount) {
+      val userObject = TreeUtil.getUserObject(tree.getPathForRow(row).lastPathComponent)
+      val text = popupStep.getNodeText(userObject) ?: continue
+      result[text] = renderer.getIcon(userObject, false)
+    }
+    result
+  }
+
+  private fun buildTestTree(filter: String? = null): Tree {
+    repositoryManager.updateAllRepositories()
+    return invokeAndWaitIfNeeded {
+      val holder = GitRepositoriesHolder.getInstance(project)
+      val repositories = holder.getAll()
+      val tree = Tree()
+      val preferredSelection = checkNotNull(holder.get(repo.repositoryId()))
+      popupStep = GitDefaultBranchesPopupStep.create(project, preferredSelection, repositories)
+      tree.cellRenderer = GitDefaultBranchesTreeRenderer(popupStep)
+      tree.model = popupStep.treeModel
+      popupStep.updateTreeModelIfNeeded(tree, filter)
+      popupStep.setSearchPattern(filter)
+      tree.also { TreeTestUtil(it).expandAll() }
+    }
+  }
+}

--- a/plugins/git4idea/tests/git4idea/test/MockGitRepositoryModel.kt
+++ b/plugins/git4idea/tests/git4idea/test/MockGitRepositoryModel.kt
@@ -33,6 +33,7 @@ internal class MockGitRepositoryModel(repo: GitRepository) : GitRepositoryModel 
     override val revision: @NlsSafe GitHash? = repo.currentRevision?.let { GitHash(it) }
     override val localBranches: Set<GitStandardLocalBranch> = repo.info.localBranchesWithHashes.keys
     override val remoteBranches: Set<GitStandardRemoteBranch> = repo.info.remoteBranchesWithHashes.keys.filterIsInstance<GitStandardRemoteBranch>().toSet()
+    override val upstreamGoneBranches: Set<GitStandardLocalBranch> = repo.info.upstreamGoneBranches.filterIsInstance<GitStandardLocalBranch>().toSet()
     override val tags: Set<GitTag>
       get() = throw UnsupportedOperationException()
     override val recentBranches: List<GitStandardLocalBranch> = repo.branches.recentCheckoutBranches


### PR DESCRIPTION
## What

Adds a warning icon (and tooltip note) in the branches tree for local branches whose configured upstream has been deleted on the remote — git's `gone` state, e.g. after `fetch --prune` removes the stale remote-tracking ref.

## Why

Orphaned branches were previously indistinguishable from healthy ones in the branches tree, so there was no signal that a branch's upstream is gone and the branch is a cleanup candidate.

## How

- Such branches keep their `branch.<name>.merge`/`remote` config but have **no** resolved `GitBranchTrackInfo`, so they can't be detected from tracking info. They're found by parsing the raw git config (`GitConfig.parseUpstreamGoneBranches`) and checking whether the configured upstream is still present among the known remote branches.
- The result is plumbed from the backend repo info (`GitRepoInfo.upstreamGoneBranches`) through the RPC DTO (`GitRepositoryStateDto.upstreamGoneBranches`) into the shared `GitRepositoryState`, so the frontend renderer can pick the warning icon.
- `current`/`favorite` states still take priority over the warning; tags and refs that can't track an upstream are never marked gone.
- Adds a tooltip note ("Upstream branch was deleted") in the branches dashboard tree.

## Tests

- `GitOrphanedBranchIconTest` — unit coverage for icon selection priority and `isUpstreamGone`.
- `GitOrphanedBranchWidgetTest` — end-to-end test exercising the full pipeline (git config → repo info → DTO → shared state → renderer) by pushing a branch, deleting it on the remote, pruning, and asserting the warning icon.
