### PR TITLE
remove `inspect` and `format` CLI commands

### DIFF
--- a/platform/build-scripts/src/org/jetbrains/intellij/build/impl/BuildTasksImpl.kt
+++ b/platform/build-scripts/src/org/jetbrains/intellij/build/impl/BuildTasksImpl.kt
@@ -1172,7 +1172,8 @@ private suspend fun lookForJunkFiles(context: BuildContext, paths: List<Path>) {
 internal suspend fun buildAdditionalAuthoringArtifacts(productRunner: IntellijProductRunner, context: BuildContext) {
   context.executeStep(spanBuilder("build authoring assets"), BuildOptions.DOC_AUTHORING_ASSETS_STEP) {
     val commands = listOf(
-      Pair("inspectopedia-generator", "inspections-${context.applicationInfo.productCode.lowercase()}"),
+      // inspections are disabled in rebased
+      //Pair("inspectopedia-generator", "inspections-${context.applicationInfo.productCode.lowercase()}"),
       Pair("keymap", "keymap-${context.applicationInfo.productCode.lowercase()}")
     )
     val temporaryBuildDirectory = context.paths.tempDir

--- a/platform/build-scripts/src/org/jetbrains/intellij/build/productLayout/CommunityModuleSets.kt
+++ b/platform/build-scripts/src/org/jetbrains/intellij/build/productLayout/CommunityModuleSets.kt
@@ -385,7 +385,8 @@ object CommunityModuleSets {
     module("intellij.libraries.microba")
     module("intellij.platform.diagnostic.freezeAnalyzer")
     module("intellij.platform.warmup")
-    module("intellij.platform.inspect")
+    // inspections, disabled in rebased
+    //module("intellij.platform.inspect")
     module("intellij.settingsSync.core")
     module("intellij.spellchecker")
     module("intellij.spellchecker.xml")

--- a/platform/platform-resources/src/META-INF/LangExtensions.xml
+++ b/platform/platform-resources/src/META-INF/LangExtensions.xml
@@ -2,7 +2,8 @@
 <idea-plugin>
   <extensions defaultExtensionNs="com.intellij">
     <appStarter id="traverseUI" implementation="com.intellij.ide.ui.search.TraverseUIStarter" internal="true"/>
-    <appStarter id="format" implementation="com.intellij.formatting.commandLine.FormatterStarter" bundle="messages.CodeStyleBundle" key="formatter.help"/>
+    <!-- disabled in rebased -->
+    <!--<appStarter id="format" implementation="com.intellij.formatting.commandLine.FormatterStarter" bundle="messages.CodeStyleBundle" key="formatter.help"/>-->
     <appStarter id="ideScript" implementation="com.intellij.ide.script.IdeScriptStarter" internal="true"/>
 
     <applicationService serviceInterface="com.intellij.util.Queries"


### PR DESCRIPTION
2026.2 introduced the CLI commands `idea inspect` and `idea format`. inspections and code formatting are not available in rebased, so it doesn't make sense to keep these commands.

unfortunately disabling the `inspect` plugin doesn't seem to disable everything inspection related in the IDE (eg. the "Inspections" settings menu is still visible), but i believe that's an existing issue