### PR TITLE
move pull/push buttons to the left of the branch selection dropdown

### DIFF
--- a/platform/dvcs-impl/resources/intellij.platform.vcs.dvcs.impl.xml
+++ b/platform/dvcs-impl/resources/intellij.platform.vcs.dvcs.impl.xml
@@ -70,7 +70,7 @@
       <add-to-group group-id="VcsToolbarActions" anchor="after" relative-to-action="ChangesView.ToggleCommitUi"/>
       <add-to-group group-id="VcsNavBarToolbarActions" anchor="after" relative-to-action="ChangesView.ToggleCommitUi"/>
       <add-to-group group-id="SegmentedVcsActionsBarGroup" anchor="after" relative-to-action="ChangesView.ToggleCommitUi"/>
-      <add-to-group group-id="MainToolbarVCSGroup" anchor="after" relative-to-action="main.toolbar.git.MergeRebase"/>
+      <add-to-group group-id="MainToolbarVCSGroup" anchor="after" relative-to-action="Vcs.UpdateProject"/>
     </action>
 
     <group id="Vcs.Push.Actions">

--- a/platform/vcs-impl/resources/META-INF/VcsActions.xml
+++ b/platform/vcs-impl/resources/META-INF/VcsActions.xml
@@ -46,7 +46,7 @@
     <action id="Vcs.UpdateProject" class="com.intellij.openapi.vcs.update.CommonUpdateProjectAction" icon="AllIcons.Actions.CheckOut">
       <keyboard-shortcut first-keystroke="control T" keymap="$default"/>
       <add-to-group group-id="SegmentedVcsActionsBarGroup" anchor="first"/>
-      <add-to-group group-id="MainToolbarVCSGroup" anchor="before" relative-to-action="Vcs.Push"/>
+      <add-to-group group-id="MainToolbarVCSGroup" anchor="first" />
     </action>
     <action id="Vcs.Toolbar.ShowMoreActions" class="com.intellij.openapi.vcs.actions.VcsQuickActionsToolbarPopup">
       <add-to-group group-id="SegmentedVcsActionsBarGroup" anchor="last"/>

--- a/plugins/git4idea/frontend/resources/intellij.vcs.git.frontend.xml
+++ b/plugins/git4idea/frontend/resources/intellij.vcs.git.frontend.xml
@@ -10,7 +10,7 @@
 
   <actions resource-bundle="messages.GitFrontendBundle">
     <action id="main.toolbar.git.Branches" class="com.intellij.vcs.git.frontend.widget.GitToolbarWidgetAction">
-      <add-to-group group-id="MainToolbarVCSGroup" anchor="first"/>
+      <add-to-group group-id="MainToolbarVCSGroup" />
     </action>
 
     <group id="GitMainToolbarQuickActions" searchable="false" popup="false">


### PR DESCRIPTION
this prevents users from accidentally clicking the wrong button when the green/blue arrow icons appear and slightly move the position of the buttons

fixes #162