### PR TITLE
fix customizing VCS group in the main toolbar so users can easily change the pull/push buttons back to the old position if they prefer

### DIFF
--- a/platform/platform-resources-en/src/messages/ActionsBundle.properties
+++ b/platform/platform-resources-en/src/messages/ActionsBundle.properties
@@ -372,6 +372,7 @@ group.ViewAppearanceGroup.text=_Appearance
 
 group.VcsGroups.text=_Git
 group.VcsGlobalGroup.text=VCS Group
+group.MainToolbarVCSGroup.text=VCS Group
 action.Vcs.UpdateProject.text=_Update Project
 group.VcsGroup.text=Version Control
 group.VcsFileGroupPopup.text=Version Control Group

--- a/plugins/git4idea/shared/resources/messages/GitBundle.properties
+++ b/plugins/git4idea/shared/resources/messages/GitBundle.properties
@@ -633,7 +633,6 @@ group.Git.Menu.text=_Git
 group.Git.MainMenu.RebaseActions.text=_Rebase
 group.Git.MainMenu.MergeActions.text=_Merge
 group.Git.MainMenu.LocalChanges.text=_Uncommitted Changes
-group.MainToolbarVCSGroup.text=VCS Group
 action.Git.Rebase.Skip.text=Skip Commit
 action.Git.Rebase.Skip.progress.title=Skip commit during rebase\u2026
 action.Git.Rebase.Continue.text=Continue Rebase


### PR DESCRIPTION
when i moved it from `intellij.vcs.git.shared.xml` i didn't move its translation string which seemed to cause it to not only display its id instead of its name, but for some reason also broke customizing it completely

fixes #307