### PR TITLE
fix editor log tab not being closable when "Show the log in the editor window" is disabled

### DIFF
--- a/platform/vcs-log/impl/src/com/intellij/vcs/log/ui/CanCloseVirtualLogFile.kt
+++ b/platform/vcs-log/impl/src/com/intellij/vcs/log/ui/CanCloseVirtualLogFile.kt
@@ -1,15 +1,19 @@
 package com.intellij.vcs.log.ui;
 
+import com.intellij.openapi.components.service
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFilePreCloseCheck
+import com.intellij.vcs.log.impl.CommonUiProperties
+import com.intellij.vcs.log.impl.VcsLogApplicationSettings
 import com.intellij.vcs.log.ui.editor.DefaultVcsLogFile
 
 
 class CanCloseVirtualLogFile: VirtualFilePreCloseCheck {
   /**
-   * don't allow the first vcs log window to be closed
+   * don't allow the first vcs log window to be closed (unless show in editor is disabled, in which case it should behave like it does in
+   * jetbrains IDEs)
    */
   override fun canCloseFile(file: VirtualFile): Boolean {
-    return file !is DefaultVcsLogFile || !file.isFirstLogFile
+    return file !is DefaultVcsLogFile || !file.isFirstLogFile || !service<VcsLogApplicationSettings>()[CommonUiProperties.SHOW_IN_EDITOR]
   }
 }


### PR DESCRIPTION
i can't reliably reproduce this issue where both log tabs are present so i have no idea what causes it, but at least now the editor one can be closed when it does happen.