### PR TITLE
fix crash when "Show the log in the editor window" is disabled and the user opens the git tool window for the first time

### DIFF
--- a/platform/vcs-log/impl/src/com/intellij/vcs/log/impl/IdeVcsLogManager.kt
+++ b/platform/vcs-log/impl/src/com/intellij/vcs/log/impl/IdeVcsLogManager.kt
@@ -66,8 +66,10 @@ internal class IdeVcsLogManager(
           createVcsLogFile(project, "", null)
           val editors = FileEditorManager.getInstance(project).openFile(file, false, true)
           VcsLogEditorUtil.findVcsLogUi(editors, MainVcsLogUi::class.java)
-        } else {
+        } else if (holder != null) {
           createLogUi(getMainLogUiFactory(MAIN_LOG_ID, null))
+        } else {
+          null
         }
         if (holder != null) {
           if (ui != null)


### PR DESCRIPTION
this only happened when the project was opened with the git tool window in a closed state

fixes #273 