### PR TITLE
gitignore `.idea.bazel`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .idea/mavenHomeManager.xml
 .idea/shelf
 .idea/workspace.xml
+.idea.bazel
 .jqwik-database
 /.diff
 # detekt can be configured by ./platform/jewel/detekt-rules/install-rules-to-idea.sh


### PR DESCRIPTION
no idea why bazel has randomly decided to start dumping shit into this directory