### PR TITLE
revert version number `build.txt` validation

### DIFF
--- a/platform/build-scripts/src/org/jetbrains/intellij/build/impl/BuildContextImpl.kt
+++ b/platform/build-scripts/src/org/jetbrains/intellij/build/impl/BuildContextImpl.kt
@@ -204,6 +204,10 @@ class BuildContextImpl internal constructor(
   override fun reportDistributionBuildNumber() {
     val suppliedBuildNumber = options.buildNumber
     val baseBuildNumber = SnapshotBuildNumber.BASE
+    check(suppliedBuildNumber == null || suppliedBuildNumber.startsWith(baseBuildNumber)) {
+      "Supplied build number '$suppliedBuildNumber' is expected to start with '$baseBuildNumber' base build number " +
+      "defined in ${SnapshotBuildNumber.PATH}"
+    }
     messages.setParameter("build.artifact.buildNumber", buildNumber)
     if (buildNumber != suppliedBuildNumber) {
       messages.reportBuildNumber(buildNumber)


### PR DESCRIPTION
this was leftover from the old way rebased versions worked. now that the build number is preserved from upstream, this check can be added back