### PR TITLE
fix regression (introduced when merging 2026.2) where the "Close All Tabs" and "Close Other Tabs" actions don't work when the non-closable log tab is present in the editor window

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,4 +20,4 @@ jobs:
         # currently we only run git tests. list mostly taken from platform/testFramework/testResources/tests/testGroups.properties
         # TODO: figure out what other tests we should run
         run: |
-          ./tests.cmd --module intellij.idea.community.main.tests --test "com.intellij.testFramework.vcs.*;com.intellij.tasks.vcs.*;com.intellij.vcs.*;com.intellij.toolWindow.*;com.intellij.configurationStore.DefaultProjectStoreTest"
+          ./tests.cmd --module intellij.idea.community.main.tests --test "com.intellij.testFramework.vcs.*;com.intellij.tasks.vcs.*;com.intellij.vcs.*;com.intellij.toolWindow.*;com.intellij.configurationStore.DefaultProjectStoreTest;com.intellij.openapi.fileEditor.FileEditorManagerTest"

--- a/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/FileEditorManagerImpl.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/fileEditor/impl/FileEditorManagerImpl.kt
@@ -905,28 +905,15 @@ open class FileEditorManagerImpl(
   }
 
   @RequiresEdt
-  override fun closeFilesWithChecks(filesWithWindows: List<Pair<EditorComposite, EditorWindow>>): Boolean {
-    val filesToClose = filesWithWindows.filter { it.second.getComposite(it.first.file) != null }
-    if (filesToClose.isEmpty()) {
-      return true
-    }
-    val filesToCheck = filesToClose.mapTo(LinkedHashSet()) { it.first.file }
-    if (!canCloseFiles(filesToCheck)) {
-      return false
-    }
-
-    openFileSetModificationCount.increment()
-    WriteIntentReadAction.run {
-      for (fileWithWindow in filesToClose) {
-        val window = fileWithWindow.second
-        val currentComposite = window.getComposite(fileWithWindow.first.file)
-        if (currentComposite != null) {
-          window.closeFile(file = currentComposite.file, composite = currentComposite)
-        }
-      }
-    }
-    return true
-  }
+  override fun closeFilesWithChecks(filesWithWindows: List<Pair<EditorComposite, EditorWindow>>): Boolean =
+  // in rebased we do the checks one at a time and close any closable files even if not all of them were closable.
+  // this differs from upstream which doesn't do anything if not all tabs were closable (apparently something clanker related that i
+  // dont care about). we need to change this behavior tho because the log tab is not closable
+  // TODO: figure out what the return value should be (whether all of them were closable or whether at least some were closable).
+    //  currently the result doesn't seem to be used outside of tests so i don't think it matters
+    filesWithWindows.map {
+      closeFileWithChecks(it.first.file, it.second)
+    }.any()
 
   @RequiresEdt
   override fun closeFile(file: VirtualFile, window: EditorWindow) {

--- a/platform/platform-impl/src/com/intellij/openapi/vfs/newvfs/impl/VfsRootAccess.java
+++ b/platform/platform-impl/src/com/intellij/openapi/vfs/newvfs/impl/VfsRootAccess.java
@@ -291,7 +291,8 @@ public final class VfsRootAccess {
       var enumerator = ProjectRootManager.getInstance(project).orderEntries().using(new DefaultModulesProvider(project));
       ContainerUtil.addAll(roots, enumerator.classes().getUrls());
       ContainerUtil.addAll(roots, enumerator.sources().getUrls());
-      ContainerUtil.addAll(roots, enumerator.roots(AnnotationOrderRootType.getInstance()).getUrls());
+      // disabled in rebased. AnnotationOrderRootType looks like some java thing that we disabled so this crashes
+      //ContainerUtil.addAll(roots, enumerator.roots(AnnotationOrderRootType.getInstance()).getUrls());
       return roots;
     }
     finally {

--- a/platform/platform-tests/testSrc/com/intellij/openapi/fileEditor/FileEditorManagerTest.kt
+++ b/platform/platform-tests/testSrc/com/intellij/openapi/fileEditor/FileEditorManagerTest.kt
@@ -59,6 +59,7 @@ import org.intellij.lang.annotations.Language
 import org.jetbrains.jps.model.serialization.PathMacroUtil
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -269,30 +270,24 @@ class FileEditorManagerTest {
   }
 
   @Test
-  fun testCloseFilesWithChecksRunsBatchCheckOnceAndCancelsWholeCloseSet(): Unit = timeoutRunBlocking(context = Dispatchers.UiWithModelAccess) {
+  fun testCloseFilesWithChecksKeepsNonClosableFileOpen(): Unit = timeoutRunBlocking(context = Dispatchers.UiWithModelAccess) {
     openSourceFiles("1.txt", "2.txt")
     val window = currentWindow()
     var singleChecks = 0
-    var batchFiles: List<VirtualFile> = emptyList()
     registerPreCloseCheck(object : VirtualFilePreCloseCheck {
       override fun canCloseFile(file: VirtualFile): Boolean {
         singleChecks++
-        return true
-      }
-
-      override fun canCloseFiles(files: Collection<VirtualFile>): Boolean {
-        batchFiles = files.toList()
-        return false
+        return file.name == "1.txt"
       }
     })
 
-    assertThat(manager.closeFilesWithChecks(window.allComposites.map { Pair.create(it, window) })).isFalse()
+    assertThat(manager.closeFilesWithChecks(window.allComposites.map { Pair.create(it, window) })).isTrue()
 
-    assertThat(singleChecks).isZero()
-    assertThat(batchFiles.map { it.name }).containsExactly("1.txt", "2.txt")
-    assertOpenFiles("1.txt", "2.txt")
+    assertThat(singleChecks).isEqualTo(2)
+    assertOpenFiles("2.txt")
   }
 
+  @Disabled("this behavior is disabled in rebased")
   @Test
   fun testCloseFilesWithChecksClosesWholeSetAfterBatchCheck(): Unit = timeoutRunBlocking(context = Dispatchers.UiWithModelAccess) {
     openSourceFiles("1.txt", "2.txt")


### PR DESCRIPTION
fixes #343 